### PR TITLE
Fix button interaction state in safari

### DIFF
--- a/components/button.module.css
+++ b/components/button.module.css
@@ -20,7 +20,10 @@
 
 .wrapper > :last-child {
   position: absolute;
-  inset: 0;
+  top: 0;
+  right: 0;
+  left: 0;
+  bottom: 0;
   display: grid;
   place-content: center;
   background-color: black;


### PR DESCRIPTION
This replaces the usage of `inset` in the `Button` component with old syntax, since it doesn't work on Safari.